### PR TITLE
refactor build process, build onefile, upgrade to v2.1.0, add homebrew release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - name: Create virtual environment
         run: make venv
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,14 +40,16 @@ jobs:
 
       - name: Set CLI version output
         id: cli_version
+        shell: bash
         run: |
           dist/localstack --version
           echo "number=$(dist/localstack --version)" >> $GITHUB_OUTPUT
 
       - name: Archive distribution
+        shell: bash
         run: |
           cd dist/
-          tar -czf localstack-cli-${{steps.cli_version.outputs.number}}-${{ matrix.os }}.tar.gz ./
+          tar -czf localstack-cli-${{steps.cli_version.outputs.number}}-${{ matrix.os }}.tar.gz localstack
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
             os: linux
             arch: amd64
     runs-on: ${{ matrix.runner }}
+    outputs:
+      cli_version: ${{ steps.cli_version.outputs.cli_version }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
@@ -84,33 +86,33 @@ jobs:
         shell: bash
         run: |
           dist-bin/localstack --version
-          echo "number=$(dist-bin/localstack --version)" >> $GITHUB_OUTPUT
+          echo "cli_version=$(dist-bin/localstack --version)" >> $GITHUB_OUTPUT
 
       - name: Archive binary distribution
         shell: bash
         run: |
           cd dist-bin/
           # use wildcard - localstack* - for windows (.exe file extension)
-          tar -czf localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}.tar.gz localstack*
+          tar -czf localstack-cli_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}.tar.gz localstack*
           rm localstack
 
       - name: Archive folder distribution
         shell: bash
         run: |
           cd dist-dir/
-          tar -czf localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}-dir.tar.gz localstack
+          tar -czf localstack-cli_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}-dir.tar.gz localstack
           rm -r localstack
 
       - name: Upload binary artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}
+          name: localstack-cli_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}
           path: 'dist-bin/*'
 
       - name: Upload folder artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}-dir
+          name: localstack-cli_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}-dir
           path: 'dist-dir/*'
 
   release:
@@ -125,8 +127,19 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: builds
+
+      - name: Generate Checksums
+        run: |
+          # move all files from the builds subdirectories to the builds root folder
+          find ./builds/ -type f -print0 | xargs -0 mv -t ./builds/
+          # remove all (empty) subdirectories
+          find ./builds/ -mindepth 1 -maxdepth 1 -type d -print0 | xargs -r0 rm -R
+          # generate the checksums
+          cd builds
+          sha256sum *.tar.gz > localstack-cli_${{needs.build.outputs.cli_version}}_checksums.txt
+
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: 'builds/**/*'
+          files: 'builds/*'
           draft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,5 +156,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: 'builds/*'
-          # TODO change
-          draft: false
+          draft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     needs:
       - build
+    permissions:
+      contents: write
     steps:
       - name: Download Builds
         uses: actions/download-artifact@v3
@@ -88,4 +90,4 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: 'builds/*'
+          files: 'builds/**/*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,42 +38,63 @@ jobs:
         run: make venv
 
       - name: Build using pyinstaller
-        run: make build
+        shell: bash
+        run: make clean all
 
       - name: Smoke tests
         run: |
-          ls dist/
-          dist/localstack --help
-          dist/localstack config show
-
-      # TODO Add more tests here
+          ls dist-bin/
+          cd dist-bin
+          # show the help
+          ./localstack --help
+          # show the config
+          ./localstack config show
+          # start community
+          ./localstack start -d
+          ./localstack wait -t 300
+          ./localstack status services --format plain
+          ./localstack status services --format plain | grep "s3=available"
+          ./localstack stop
+          # start pro
+          LOCALSTACK_API_KEY=${{ secrets.TEST_LOCALSTACK_API_KEY }} ./localstack start -d
+          ./localstack wait -t 300
+          ./localstack status services --format plain
+          ./localstack status services --format plain | grep "xray=available"
+          ./localstack stop
 
       - name: Set CLI version output
         id: cli_version
         shell: bash
         run: |
-          dist/localstack --version
-          echo "number=$(dist/localstack --version)" >> $GITHUB_OUTPUT
+          dist-bin/localstack --version
+          echo "number=$(dist-bin/localstack --version)" >> $GITHUB_OUTPUT
 
-      - name: Archive distribution (Linux/MacOS)
-        if: matrix.os != 'windows'
+      - name: Archive binary distribution
+        shell: bash
         run: |
-          cd dist/
-          tar -czf localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}.tar.gz localstack
+          cd dist-bin/
+          # use wildcard - localstack* - for windows (.exe file extension)
+          tar -czf localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}.tar.gz localstack*
           rm localstack
 
-      - name: Archive distribution (Windows)
-        if: matrix.os == 'windows'
+      - name: Archive folder distribution
+        shell: bash
         run: |
-          cd dist/
-          Compress-Archive localstack.exe localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}.zip
-          rm localstack.exe
+          cd dist-dir/
+          tar -czf localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}-dir.tar.gz localstack
+          rm localstack
 
-      - name: Upload artifacts
+      - name: Upload binary artifacts
         uses: actions/upload-artifact@v3
         with:
           name: localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}
-          path: 'dist/*'
+          path: 'dist-bin/*'
+
+      - name: Upload folder artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}-dir
+          path: 'dist-dir/*'
 
   release:
     runs-on: ubuntu-latest
@@ -91,3 +112,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: 'builds/**/*'
+          draft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
           - runner: ubuntu-20.04
             os: linux
             arch: amd64
+          # TODO add a linux arm64 runner here
+
     runs-on: ${{ matrix.runner }}
     outputs:
       cli_version: ${{ steps.cli_version.outputs.cli_version }}
@@ -88,31 +90,36 @@ jobs:
           dist-bin/localstack --version
           echo "cli_version=$(dist-bin/localstack --version)" >> $GITHUB_OUTPUT
 
-      - name: Archive binary distribution
-        shell: bash
+      - name: Archive distribution (Linux, MacOS)
+        if: matrix.os != 'windows'
         run: |
           cd dist-bin/
-          # use wildcard - localstack* - for windows (.exe file extension)
-          tar -czf localstack-cli_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}.tar.gz localstack*
+          tar -czf ${{github.event.repository.name}}_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}-onefile.tar.gz localstack
           rm localstack
+          cd ../dist-dir/
+          tar -czf ${{github.event.repository.name}}_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}.tar.gz localstack
+          rm -r localstack
 
-      - name: Archive folder distribution
-        shell: bash
+      - name: Archive distribution (Windows)
+        if: matrix.os == 'windows'
         run: |
-          cd dist-dir/
-          tar -czf localstack-cli_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}-dir.tar.gz localstack
+          cd dist-bin/
+          Compress-Archive localstack.exe ${{github.event.repository.name}}_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}.zip
+          rm localstack.exe
+          cd ../dist-dir/
+          Compress-Archive localstack ${{github.event.repository.name}}_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}-onefile.zip
           rm -r localstack
 
       - name: Upload binary artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: localstack-cli_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}
+          name: ${{github.event.repository.name}}_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}-onefile
           path: 'dist-bin/*'
 
       - name: Upload folder artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: localstack-cli_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}-dir
+          name: ${{github.event.repository.name}}_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}
           path: 'dist-dir/*'
 
   release:
@@ -128,6 +135,13 @@ jobs:
         with:
           path: builds
 
+      # TODO remove this section once we have native darwin arm64 builds
+      # This step is currently necessary for the homebrew action to pick up the MacOS AMD64 package for MacOS ARM64 / M1
+      - name: Use Darwin AMD64 for Darwin ARM64
+        run: |
+          cp ./builds/${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_darwin_amd64/* ./builds/${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_darwin_amd64/${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_darwin_arm64.tar.gz
+          cp ./builds/${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_darwin_amd64-onefile/* ./builds/${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_darwin_amd64-onefile/${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_darwin_arm64-onefile.tar.gz
+
       - name: Generate Checksums
         run: |
           # move all files from the builds subdirectories to the builds root folder
@@ -136,7 +150,7 @@ jobs:
           find ./builds/ -mindepth 1 -maxdepth 1 -type d -print0 | xargs -r0 rm -R
           # generate the checksums
           cd builds
-          sha256sum *.tar.gz > localstack-cli_${{needs.build.outputs.cli_version}}_checksums.txt
+          sha256sum *.tar.gz > ${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_checksums.txt
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,17 @@ jobs:
         run: make clean all
 
       - name: Setup Docker on MacOS
-        if: matrix.os == 'darwin'
+        # TODO re-enable
+        if: false
+        # if: matrix.os == 'darwin'
         run: |
           brew install docker
           colima start
 
       - name: Non-Docker Smoke tests
         shell: bash
+        # TODO re-enable
+        if: false
         run: |
           ls dist-bin/
           cd dist-bin
@@ -64,7 +68,9 @@ jobs:
       - name: Docker Smoke tests (Linux, MacOS)
         shell: bash
         # GitHub Windows runner cannot run Docker containers (https://github.com/orgs/community/discussions/25491)
-        if: matrix.os != 'windows'
+        # TODO re-enable
+        if: false
+        # if: matrix.os != 'windows'
         run: |
           # Pull images to avoid making smoke tests vulnerable to system behavior (docker pull speed)
           docker pull localstack/localstack

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           cd dist-dir/
           tar -czf localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}-dir.tar.gz localstack
-          rm localstack
+          rm -r localstack
 
       - name: Upload binary artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,32 +94,32 @@ jobs:
         if: matrix.os != 'windows'
         run: |
           cd dist-bin/
-          tar -czf ${{github.event.repository.name}}_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}-onefile.tar.gz localstack
+          tar -czf ${{github.event.repository.name}}-${{steps.cli_version.outputs.cli_version}}-${{ matrix.os }}-${{ matrix.arch }}-onefile.tar.gz localstack
           rm localstack
           cd ../dist-dir/
-          tar -czf ${{github.event.repository.name}}_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}.tar.gz localstack
+          tar -czf ${{github.event.repository.name}}-${{steps.cli_version.outputs.cli_version}}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz localstack
           rm -r localstack
 
       - name: Archive distribution (Windows)
         if: matrix.os == 'windows'
         run: |
           cd dist-bin/
-          Compress-Archive localstack.exe ${{github.event.repository.name}}_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}.zip
+          Compress-Archive localstack.exe ${{github.event.repository.name}}-${{steps.cli_version.outputs.cli_version}}-${{ matrix.os }}-${{ matrix.arch }}.zip
           rm localstack.exe
           cd ../dist-dir/
-          Compress-Archive localstack ${{github.event.repository.name}}_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}-onefile.zip
+          Compress-Archive localstack ${{github.event.repository.name}}-${{steps.cli_version.outputs.cli_version}}-${{ matrix.os }}-${{ matrix.arch }}-onefile.zip
           rm -r localstack
 
       - name: Upload binary artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{github.event.repository.name}}_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}-onefile
+          name: ${{github.event.repository.name}}-${{steps.cli_version.outputs.cli_version}}-${{ matrix.os }}-${{ matrix.arch }}-onefile
           path: 'dist-bin/*'
 
       - name: Upload folder artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: ${{github.event.repository.name}}_${{steps.cli_version.outputs.cli_version}}_${{ matrix.os }}_${{ matrix.arch }}
+          name: ${{github.event.repository.name}}-${{steps.cli_version.outputs.cli_version}}-${{ matrix.os }}-${{ matrix.arch }}
           path: 'dist-dir/*'
 
   release:
@@ -139,8 +139,8 @@ jobs:
       # This step is currently necessary for the homebrew action to pick up the MacOS AMD64 package for MacOS ARM64 / M1
       - name: Use Darwin AMD64 for Darwin ARM64
         run: |
-          cp ./builds/${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_darwin_amd64/* ./builds/${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_darwin_amd64/${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_darwin_arm64.tar.gz
-          cp ./builds/${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_darwin_amd64-onefile/* ./builds/${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_darwin_amd64-onefile/${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_darwin_arm64-onefile.tar.gz
+          cp ./builds/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-amd64/* ./builds/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-amd64/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-arm64.tar.gz
+          cp ./builds/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-amd64-onefile/* ./builds/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-amd64-onefile/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-arm64-onefile.tar.gz
 
       - name: Generate Checksums
         run: |
@@ -150,10 +150,11 @@ jobs:
           find ./builds/ -mindepth 1 -maxdepth 1 -type d -print0 | xargs -r0 rm -R
           # generate the checksums
           cd builds
-          sha256sum *.tar.gz > ${{github.event.repository.name}}_${{needs.build.outputs.cli_version}}_checksums.txt
+          sha256sum *.{tar.gz,zip} > ${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-checksums.txt
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: 'builds/*'
-          draft: true
+          # TODO change
+          draft: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,14 +46,8 @@ jobs:
           dist/localstack --version
           echo "number=$(dist/localstack --version)" >> $GITHUB_OUTPUT
 
-      - name: Archive distribution
-        shell: bash
-        run: |
-          cd dist/
-          tar -czf localstack-cli-${{steps.cli_version.outputs.number}}-${{ matrix.os }}.tar.gz localstack
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: localstack-cli-${{steps.cli_version.outputs.number}}-${{ matrix.os }}
-          path: dist/localstack-cli-${{steps.cli_version.outputs.number}}-${{ matrix.os }}.tar.gz
+          path: dist/localstack

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,14 +63,14 @@ jobs:
           # show the config
           ./localstack config show
 
-      - name: Docker Smoke tests (Linux, MacOS)
+      - name: Community Docker Smoke tests (Linux, MacOS)
         shell: bash
         # GitHub Windows runner cannot run Docker containers (https://github.com/orgs/community/discussions/25491)
-        if: matrix.os != 'windows'
+        # Skip these checks for forks (forks do not have access to the LocalStack Pro API key)
+        if: matrix.os != 'windows' && !github.event.pull_request.head.repo.fork
         run: |
           # Pull images to avoid making smoke tests vulnerable to system behavior (docker pull speed)
           docker pull localstack/localstack
-          docker pull localstack/localstack-pro
           cd dist-bin
           # start community
           ./localstack start -d
@@ -78,6 +78,16 @@ jobs:
           ./localstack status services --format plain
           ./localstack status services --format plain | grep "s3=available"
           ./localstack stop
+
+      - name: Pro Docker Smoke tests (Linux, MacOS)
+        shell: bash
+        # GitHub Windows runner cannot run Docker containers (https://github.com/orgs/community/discussions/25491)
+        # Skip these checks for forks (forks do not have access to the LocalStack Pro API key)
+        if: matrix.os != 'windows' && !github.event.pull_request.head.repo.fork
+        run: |
+          # Pull images to avoid making smoke tests vulnerable to system behavior (docker pull speed)
+          docker pull localstack/localstack-pro
+          cd dist-bin
           # start pro
           LOCALSTACK_API_KEY=${{ secrets.TEST_LOCALSTACK_API_KEY }} ./localstack start -d
           ./localstack wait -t 60

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,17 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
+      - name: Setup Python (GitHub Runner)
+        if: ${{ !contains(matrix.runner, 'buildjet') }}
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+
+      - name: Setup Python (BuildJet Runner)
+        if: contains(matrix.runner, 'buildjet')
+        uses: gabrielfalcao/pyenv-action@v11
+        with:
+          default: '3.10'
 
       - name: Create virtual environment
         run: make venv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,17 @@ jobs:
           brew install docker
           colima start
 
-      - name: Smoke tests
+      - name: Pull Docker Images
+        # Pull images to avoid making smoke tests vulnerable to system behavior (docker pull speed)
         run: |
+          docker pull localstack/localstack
+          docker pull localstack/localstack-pro
+
+      - name: Smoke tests
+        shell: bash
+        run: |
+          # try to fix https://github.com/localstack/localstack-packaged-cli/issues/2
+          export PYTHONUTF8=1
           ls dist-bin/
           cd dist-bin
           # show the help
@@ -57,13 +66,13 @@ jobs:
           ./localstack config show
           # start community
           ./localstack start -d
-          ./localstack wait -t 300
+          ./localstack wait -t 60
           ./localstack status services --format plain
           ./localstack status services --format plain | grep "s3=available"
           ./localstack stop
           # start pro
           LOCALSTACK_API_KEY=${{ secrets.TEST_LOCALSTACK_API_KEY }} ./localstack start -d
-          ./localstack wait -t 300
+          ./localstack wait -t 60
           ./localstack status services --format plain
           ./localstack status services --format plain | grep "xray=available"
           ./localstack stop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,13 +40,13 @@ jobs:
         if: ${{ !contains(matrix.runner, 'buildjet') }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.10.11'
 
       - name: Setup Python (BuildJet Runner)
         if: contains(matrix.runner, 'buildjet')
-        uses: gabrielfalcao/pyenv-action@v11
+        uses: gabrielfalcao/pyenv-action@v14
         with:
-          default: '3.10'
+          default: '3.10.11'
 
       - name: Create virtual environment
         run: make venv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,23 +47,25 @@ jobs:
           brew install docker
           colima start
 
-      - name: Pull Docker Images
-        # Pull images to avoid making smoke tests vulnerable to system behavior (docker pull speed)
-        run: |
-          docker pull localstack/localstack
-          docker pull localstack/localstack-pro
-
-      - name: Smoke tests
+      - name: Non-Docker Smoke tests
         shell: bash
         run: |
-          # try to fix https://github.com/localstack/localstack-packaged-cli/issues/2
-          export PYTHONUTF8=1
           ls dist-bin/
           cd dist-bin
           # show the help
           ./localstack --help
           # show the config
           ./localstack config show
+
+      - name: Docker Smoke tests (Linux, Darwin)
+        shell: bash
+        # GitHub Windows runner cannot run Docker containers (https://github.com/orgs/community/discussions/25491)
+        if: matrix.os != 'windows'
+        run: |
+          # Pull images to avoid making smoke tests vulnerable to system behavior (docker pull speed)
+          docker pull localstack/localstack
+          docker pull localstack/localstack-pro
+          cd dist-bin
           # start community
           ./localstack start -d
           ./localstack wait -t 60

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         id: cli_version
         run: |
           dist/localstack --version
-          echo "number=$(dist/localstack/localstack --version)" >> $GITHUB_OUTPUT
+          echo "number=$(dist/localstack --version)" >> $GITHUB_OUTPUT
 
       - name: Archive distribution
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
           # show the config
           ./localstack config show
 
-      - name: Docker Smoke tests (Linux, Darwin)
+      - name: Docker Smoke tests (Linux, MacOS)
         shell: bash
         # GitHub Windows runner cannot run Docker containers (https://github.com/orgs/community/discussions/25491)
         if: matrix.os != 'windows'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-10.15, windows-latest, ubuntu-latest]
+        os: [macos-11, windows-2019, ubuntu-20.04]
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Create virtual environment
         run: make venv
@@ -28,23 +28,25 @@ jobs:
 
       - name: Smoke test
         run: |
-          ls dist/localstack
-          dist/localstack/localstack --help
-          dist/localstack/localstack config show
+          ls dist/
+          dist/localstack --help
+          dist/localstack config show
+
+      # TODO Add more tests here
 
       - name: Set CLI version output
         id: cli_version
         run: |
-          dist/localstack/localstack --version
-          echo "::set-output name=number::$(dist/localstack/localstack --version)"
+          dist/localstack --version
+          echo "number=$(dist/localstack/localstack --version)" >> $GITHUB_OUTPUT
 
       - name: Archive distribution
         run: |
           cd dist/
-          tar -czf localstack-cli-${{steps.cli_version.outputs.number}}-${{ matrix.os }}.tar.gz localstack
+          tar -czf localstack-cli-${{steps.cli_version.outputs.number}}-${{ matrix.os }}.tar.gz ./
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: localstack-cli-${{steps.cli_version.outputs.number}}-${{ matrix.os }}
           path: dist/localstack-cli-${{steps.cli_version.outputs.number}}-${{ matrix.os }}.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build:
-
     strategy:
       matrix:
         include:
@@ -24,7 +23,6 @@ jobs:
           - runner: ubuntu-20.04
             os: linux
             arch: amd64
-
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out Git repository
@@ -40,7 +38,7 @@ jobs:
       - name: Build using pyinstaller
         run: make build
 
-      - name: Smoke test
+      - name: Smoke tests
         run: |
           ls dist/
           dist/localstack --help
@@ -55,8 +53,37 @@ jobs:
           dist/localstack --version
           echo "number=$(dist/localstack --version)" >> $GITHUB_OUTPUT
 
+      - name: Archive distribution (Linux/MacOS)
+        if: matrix.os != 'windows'
+        run: |
+          cd dist/
+          tar -czf localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}.tar.gz localstack
+          rm localstack
+
+      - name: Archive distribution (Windows)
+        if: matrix.os == 'windows'
+        run: |
+          cd dist/
+          Compress-Archive localstack.exe localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}.zip
+          rm localstack.exe
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
           name: localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}
           path: 'dist/*'
+
+  release:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build
+    steps:
+      - name: Download Builds
+        uses: actions/download-artifact@v3
+        with:
+          path: builds
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: 'builds/*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,9 @@ jobs:
           - runner: ubuntu-20.04
             os: linux
             arch: amd64
-          # TODO add a linux arm64 runner here
+          - runner: buildjet-2vcpu-ubuntu-2204-arm
+            os: linux
+            arch: arm64
 
     runs-on: ${{ matrix.runner }}
     outputs:
@@ -46,17 +48,13 @@ jobs:
         run: make clean all
 
       - name: Setup Docker on MacOS
-        # TODO re-enable
-        if: false
-        # if: matrix.os == 'darwin'
+        if: matrix.os == 'darwin'
         run: |
           brew install docker
           colima start
 
       - name: Non-Docker Smoke tests
         shell: bash
-        # TODO re-enable
-        if: false
         run: |
           ls dist-bin/
           cd dist-bin
@@ -68,9 +66,7 @@ jobs:
       - name: Docker Smoke tests (Linux, MacOS)
         shell: bash
         # GitHub Windows runner cannot run Docker containers (https://github.com/orgs/community/discussions/25491)
-        # TODO re-enable
-        if: false
-        # if: matrix.os != 'windows'
+        if: matrix.os != 'windows'
         run: |
           # Pull images to avoid making smoke tests vulnerable to system behavior (docker pull speed)
           docker pull localstack/localstack
@@ -143,7 +139,8 @@ jobs:
 
       # TODO remove this section once we have native darwin arm64 builds
       # This step is currently necessary for the homebrew action to pick up the MacOS AMD64 package for MacOS ARM64 / M1
-      - name: Use Darwin AMD64 for Darwin ARM64
+      # GitHub Roadmap: https://github.com/github/roadmap/issues/528
+      - name: (Intermediate) Use Darwin AMD64 for Darwin ARM64
         run: |
           cp ./builds/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-amd64/* ./builds/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-amd64/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-arm64.tar.gz
           cp ./builds/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-amd64-onefile/* ./builds/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-amd64-onefile/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-arm64-onefile.tar.gz
@@ -163,3 +160,4 @@ jobs:
         with:
           files: 'builds/*'
           draft: true
+          token: ${{ secrets.LOCALSTACK_GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,12 @@ jobs:
         shell: bash
         run: make clean all
 
+      - name: Setup Docker on MacOS
+        if: matrix.os == 'darwin'
+        run: |
+          brew install docker
+          colima start
+
       - name: Smoke tests
         run: |
           ls dist-bin/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build with pyinstaller
+name: Build / Release
 
 on:
   pull_request:
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,22 @@ on:
   workflow_dispatch:
 
 jobs:
-  release:
-    runs-on: ${{ matrix.os }}
+  build:
 
     strategy:
       matrix:
-        os: [macos-11, windows-2019, ubuntu-20.04]
+        include:
+          - runner: macos-11
+            os: darwin
+            arch: amd64
+          - runner: windows-2019
+            os: windows
+            arch: amd64
+          - runner: ubuntu-20.04
+            os: linux
+            arch: amd64
 
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
@@ -49,5 +58,5 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: localstack-cli-${{steps.cli_version.outputs.number}}-${{ matrix.os }}
-          path: dist/localstack
+          name: localstack-cli_${{steps.cli_version.outputs.number}}_${{ matrix.os }}_${{ matrix.arch }}
+          path: 'dist/*'

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,59 @@
+# Start Homebrew Releaser when a new GitHub release of the CLI package is published
+on:
+  release:
+    types: [published]
+
+jobs:
+  homebrew-releaser:
+    runs-on: ubuntu-latest
+    name: homebrew-releaser
+    steps:
+      - name: Add published release to Homebrew Tap
+        uses: Justintime50/homebrew-releaser@v1
+        with:
+          # The name of the homebrew tap to publish your formula to as it appears on GitHub.
+          # Required - strings
+          # TODO change
+          homebrew_owner: alexrashed
+          homebrew_tap: homebrew-tap
+
+          # Logs debugging info to console.
+          # Default is shown - boolean
+          # TODO change
+          debug: true
+
+          # The name of the folder in your homebrew tap where formula will be committed to.
+          # Default is shown - string
+          formula_folder: Formula
+
+          # The Personal Access Token (saved as a repo secret) that has `repo` permissions for the repo running the action AND Homebrew tap you want to release to.
+          # Required - string
+          github_token: ${{ secrets.LOCALSTACK_GITHUB_TOKEN }}
+
+          # Git author info used to commit to the homebrew tap.
+          # Defaults are shown - strings
+          commit_owner: localstack-bot
+          commit_email: 88328844+localstack-bot@users.noreply.github.com
+
+          # Custom install command for your formula.
+          # Required - string
+          install: |
+            libexec.install Dir["*"]
+            bin.install_symlink libexec/"localstack"
+
+          # Custom test command for your formula so you can run `brew test`.
+          # Optional - string
+          test: |
+            assert_match /LocalStack Command Line Interface/, shell_output("#{bin}/localstack --help", 0)
+
+          # Adds URL and checksum targets for different OS and architecture pairs. Using this option assumes
+          # a tar archive exists on your GitHub repo with the following URL pattern (this cannot be customized):
+          # https://github.com/{GITHUB_OWNER}/{REPO_NAME}/releases/download/{TAG}/{REPO_NAME}-{VERSION}-{OPERATING_SYSTEM}-{ARCHITECTURE}.tar.gz'
+          # Darwin AMD pre-existing path example: https://github.com/justintime50/myrepo/releases/download/v1.2.0/myrepo-1.2.0-darwin-amd64.tar.gz
+          # Linux ARM pre-existing path example: https://github.com/justintime50/myrepo/releases/download/v1.2.0/myrepo-1.2.0-linux-arm64.tar.gz
+          # Optional - booleans
+          target_darwin_amd64: true
+          target_darwin_arm64: true
+          target_linux_amd64: true
+          # TODO activate once linux-arm-build is activated
+          target_linux_arm64: false

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,8 +1,8 @@
-# Start Homebrew Releaser when a new GitHub release of the CLI package is published
 name: Release Homebrew Tap
 
 on:
   release:
+    # Start Homebrew Releaser when a new GitHub release of the CLI package is _published_
     types: [published]
 
 jobs:
@@ -15,13 +15,11 @@ jobs:
         with:
           # The name of the homebrew tap to publish your formula to as it appears on GitHub.
           # Required - strings
-          # TODO change
-          homebrew_owner: alexrashed
+          homebrew_owner: localstack
           homebrew_tap: homebrew-tap
 
           # Logs debugging info to console.
           # Default is shown - boolean
-          # TODO change
           debug: true
 
           # The name of the folder in your homebrew tap where formula will be committed to.
@@ -40,6 +38,7 @@ jobs:
 
           # Custom install command for your formula.
           # Required - string
+          # The indentation is on purpose to fix the multiline indentation in the final formula
           install: |
             libexec.install Dir["*"]
                 bin.install_symlink libexec/"localstack"
@@ -58,5 +57,4 @@ jobs:
           target_darwin_amd64: true
           target_darwin_arm64: true
           target_linux_amd64: true
-          # TODO activate once linux-arm-build is activated
-          target_linux_arm64: false
+          target_linux_arm64: true

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,4 +1,6 @@
 # Start Homebrew Releaser when a new GitHub release of the CLI package is published
+name: Release Homebrew Tap
+
 on:
   release:
     types: [published]
@@ -30,6 +32,7 @@ jobs:
           # Required - string
           github_token: ${{ secrets.LOCALSTACK_GITHUB_TOKEN }}
 
+
           # Git author info used to commit to the homebrew tap.
           # Defaults are shown - strings
           commit_owner: localstack-bot
@@ -39,7 +42,7 @@ jobs:
           # Required - string
           install: |
             libexec.install Dir["*"]
-            bin.install_symlink libexec/"localstack"
+                bin.install_symlink libexec/"localstack"
 
           # Custom test command for your formula so you can run `brew test`.
           # Optional - string
@@ -52,8 +55,8 @@ jobs:
           # Darwin AMD pre-existing path example: https://github.com/justintime50/myrepo/releases/download/v1.2.0/myrepo-1.2.0-darwin-amd64.tar.gz
           # Linux ARM pre-existing path example: https://github.com/justintime50/myrepo/releases/download/v1.2.0/myrepo-1.2.0-linux-arm64.tar.gz
           # Optional - booleans
-          target_darwin_amd64: true
-          target_darwin_arm64: true
-          target_linux_amd64: true
+          # target_darwin_amd64: true
+          # target_darwin_arm64: true
+          # target_linux_amd64: true
           # TODO activate once linux-arm-build is activated
           target_linux_arm64: false

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -55,8 +55,8 @@ jobs:
           # Darwin AMD pre-existing path example: https://github.com/justintime50/myrepo/releases/download/v1.2.0/myrepo-1.2.0-darwin-amd64.tar.gz
           # Linux ARM pre-existing path example: https://github.com/justintime50/myrepo/releases/download/v1.2.0/myrepo-1.2.0-linux-arm64.tar.gz
           # Optional - booleans
-          # target_darwin_amd64: true
-          # target_darwin_arm64: true
-          # target_linux_amd64: true
+          target_darwin_amd64: true
+          target_darwin_arm64: true
+          target_linux_amd64: true
           # TODO activate once linux-arm-build is activated
           target_linux_arm64: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Build dist folders
+dist-bin
+dist-dir
+
+# IntelliJ
 .idea/
 *.iml
 *~

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,13 @@ $(VENV_ACTIVATE): requirements.txt
 
 # currently botocore and boto3 are required because patch.py of localstack-client>=1.33
 # once that is remedied, we can exclude boto3 and botocore modules again
-dist/localstack/localstack: main.py
+dist/localstack: main.py
 	$(VENV_RUN); pyinstaller main.py \
 		$(PYINSTALLER_ARGS) -n localstack \
-		--exclude-module moto \
-		--hidden-import docker
-	rm -rf dist/localstack/botocore/data
+		--additional-hooks-dir hooks \
+		--onefile
 
-build: venv dist/localstack/localstack
+build: venv dist/localstack
 
 clean:
 	rm -rf build/

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ endif
 
 VENV_RUN = . $(VENV_ACTIVATE)
 
-all: venv dist-bin/localstack dist-dir/localstack
+all: dist-bin/localstack dist-dir/localstack
 
 venv: $(VENV_ACTIVATE)
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ $(VENV_ACTIVATE): requirements.txt
 dist/localstack: main.py
 	$(VENV_RUN); pyinstaller main.py \
 		$(PYINSTALLER_ARGS) -n localstack \
+		--hidden-import localstack_ext.cli.localstack \
 		--additional-hooks-dir hooks \
 		--onefile
 

--- a/README.md
+++ b/README.md
@@ -5,20 +5,6 @@ Repository for the build config that packages the localstack cli into a standalo
 
 ## Build
 
-### python3-dev
-
-You need Python developer version libraries in your path to be able to build the distribution.
-
-For most of us who use pyenv, this is done with
-
-```bash
-pyenv install 3.8-dev
-pyenv local 3.8-dev
-python --version
-```
-
-should print something like `Python 3.8.15+`.
-
 ### make all
 
 Just run

--- a/README.md
+++ b/README.md
@@ -5,12 +5,23 @@ This repository contains building instructions for binary builds of the LocalSta
 It does not contain the actual source for the CLI, since the LocalStack CLI is basically just the Python package `localstack` (published on PyPi) with it's install dependencies (and without any extras).
 This is why this repository just contains the build config and pipeline that packages the LocalStack CLI python package into a standalone binary using PyInstaller.
 
+## Creating a Release
+In order to create a release, just perform the following tasks:
+- Create a commit which sets a new explicit version for `localstack` in the `requirements.txt`.
+  - For example: `localstack==2.1.0`
+- Create a tag for the commit: `v<version>`.
+  - For example: `git tag v2.1.0`
+- Push the tag (`git push origin v<version>`)
+- This will trigger the following actions:
+  - The tag will trigger the ["Build / Release"](.github/workflows/build.yml) GitHub workflow.
+  - It will build the binaries for the different systems and create a GitHub release draft.
+- Publish the GitHub release draft.
+- This will trigger the ["Release Homebrew Tap"](.github/workflows/homebrew.yml) GitHub workflow.
+  - It will take the release artifacts and update the Homebrew formula in [localstack/homebrew-tap](https://github.com/localstack/homebrew-tap).
+
 ## Manual Build
-
 ### python3-dev
-
 You need Python developer version libraries in your path to be able to build the distribution.
-
 For most of us who use pyenv, this is done with:
 - MacOS:
   ```bash
@@ -29,13 +40,10 @@ python --version
 This should print something like `Python 3.10.11+`.
 
 ### make all
-
 Just run
-
 ```bash
 make clean all
 ```
-
 in `dist/localstack` you should now find the binary assets.
 
 If you want a single binary you can run `PYINSTALLER_ARGS=-F make clean all`.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-localstack-packaged-cli
+LocalStack CLI
 =======================
 
-Repository for the build config that packages the localstack cli into a standalone binary.
+This repository contains building instructions for binary builds of the LocalStack CLI.
+It does not contain the actual source for the CLI, since the LocalStack CLI is basically just the Python package `localstack` (published on PyPi) with it's install dependencies (and without any extras).
+This is why this repository just contains the build config and pipeline that packages the LocalStack CLI python package into a standalone binary using PyInstaller.
 
-## Build
+## Manual Build
 
 ### python3-dev
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,27 @@ Repository for the build config that packages the localstack cli into a standalo
 
 ## Build
 
+### python3-dev
+
+You need Python developer version libraries in your path to be able to build the distribution.
+
+For most of us who use pyenv, this is done with:
+- MacOS:
+  ```bash
+  env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.10-dev
+  ```
+- Linux:
+  ```bash
+  env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.10-dev
+  ```
+
+Activate the version:
+```
+pyenv local 3.10-dev
+python --version
+```
+This should print something like `Python 3.10.11+`.
+
 ### make all
 
 Just run

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ In order to create a release, just perform the following tasks:
 - This will trigger the ["Release Homebrew Tap"](.github/workflows/homebrew.yml) GitHub workflow.
   - It will take the release artifacts and update the Homebrew formula in [localstack/homebrew-tap](https://github.com/localstack/homebrew-tap).
 
+### Dev Releases
+If a dev release is created, the tag name has to have the same name as the version of `localstack-core` being used (because this is the output of `localstack --version`).
+Otherwise, the ["Release Homebrew Tap"](.github/workflows/homebrew.yml) GitHub workflow will not be able to find the artifacts.
+
 ## Manual Build
 ### python3-dev
 You need Python developer version libraries in your path to be able to build the distribution.
@@ -39,13 +43,14 @@ python --version
 ```
 This should print something like `Python 3.10.11+`.
 
-### make all
-Just run
+### Building
+You can build the specific versions by calling the respective make target:
 ```bash
+make clean dist-bin/localstack
+# or:
+make clean dist-dir/localstack
+# or both:
 make clean all
 ```
-in `dist/localstack` you should now find the binary assets.
-
-If you want a single binary you can run `PYINSTALLER_ARGS=-F make clean all`.
-This will create a single binary `dist/localstack`.
+You can find the binary assets in `dist-bin/` and `dist-dir`.
 The single binary has a slower startup time than the binary distribution.

--- a/hooks/hook-localstack_core.py
+++ b/hooks/hook-localstack_core.py
@@ -1,0 +1,4 @@
+from PyInstaller.utils.hooks import copy_metadata
+
+# make sure to add the entrypoints data for localstack-core
+datas = copy_metadata('localstack_core')

--- a/hooks/hook-localstack_ext.py
+++ b/hooks/hook-localstack_ext.py
@@ -1,0 +1,4 @@
+from PyInstaller.utils.hooks import copy_metadata
+
+# make sure to add the entrypoints data for localstack-ext
+datas = copy_metadata('localstack_ext')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyinstaller
-localstack>=2.0.3.dev
+localstack==2.0.3.dev20230523065743

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyinstaller
-localstack==2.0.3.dev20230523065743
+localstack==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
 pyinstaller
-localstack==2.0.1
-localstack-client==2.0
-docker>=5.0.0
-rich>=12.3
+localstack>=2.0.3.dev


### PR DESCRIPTION
This PR contains the following changes:
- It refactors the build process such that:
  - It also creates an ARM64 binary.
  - It creates both, the onefile-binary and the directory-binary distributions.
  - It automatically creates draft releases on tags with the release assets for all supported architectures.
- It adds a new workflow which updates the `localstack-cli` formula in [`localstack/homebrew-tap`](https://github.com/localstack/homebrew-tap) when a _draft_ release is _published_.
  - There already is a community driven Homebrew formula for LocalStack based on the python packages:
    - https://formulae.brew.sh/formula/localstack
    - https://github.com/Homebrew/homebrew-core/blob/master/Formula/localstack.rb
  - This formula is automatically upgraded and already shows 2.1.0: https://github.com/Homebrew/homebrew-core/pull/131979
  - In the future, once the binary distribution is final and officially promoted for all systems, we could try to reach out and migrate this formula / automation.
- Fixes the entrypoint discovery for binary distributions (by adding the respective pyinstaller hooks to ensure that the package metadata is added to the package).