### PR TITLE
update python to 3.11, dependabot, venv retry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "alexrashed"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         if: contains(matrix.runner, 'buildjet')
         uses: gabrielfalcao/pyenv-action@v16
         with:
-          default: '3.11.5'
+          default: '3.11.4'
 
       - name: Create virtual environment
         run: make venv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,16 @@ jobs:
         with:
           default: '3.11.4'
 
+      # Add a retry to avoid issues when this action is running
+      # right after the package is published on PyPi
+      # (and might not be distributed in the CDN yet)
       - name: Create virtual environment
-        run: make venv
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          retry_wait_seconds: 120
+          command: make venv
 
       - name: Build using pyinstaller
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,19 +34,19 @@ jobs:
       cli_version: ${{ steps.cli_version.outputs.cli_version }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python (GitHub Runner)
         if: ${{ !contains(matrix.runner, 'buildjet') }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10.11'
+          python-version: '3.11.5'
 
       - name: Setup Python (BuildJet Runner)
         if: contains(matrix.runner, 'buildjet')
-        uses: gabrielfalcao/pyenv-action@v14
+        uses: gabrielfalcao/pyenv-action@v16
         with:
-          default: '3.10.11'
+          default: '3.11.5'
 
       - name: Create virtual environment
         run: make venv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,19 +6,20 @@ You need Python developer version libraries in your path to be able to build the
 For most of us who use pyenv, this is done with:
 - MacOS:
   ```bash
-  env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.10-dev
+  env PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.11-dev
   ```
 - Linux:
   ```bash
-  env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.10-dev
+  env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.11-dev
   ```
 
 Activate the version:
 ```
-pyenv local 3.10-dev
+pyenv local 3.11-dev
 python --version
+
 ```
-This should print something like `Python 3.10.11+`.
+This should print something like `Python 3.11.5+`.
 
 ### Building
 You can build the specific versions by calling the respective make target:


### PR DESCRIPTION
This PR contains the following changes:
- Updates the build pipeline to Python 3.11 - see https://github.com/localstack/localstack/pull/8087
- Updates the docs to use Python 3.11.
- Updates all GitHub actions to the latest version
- Introduces Dependabot for GitHub action.
- Adds a retry to the venv setup to avoid issues with setting up the venv if the package is not yet distributed across the PyPi CDN (because this action is triggered right after the package is published).