### PR TITLE
add native Apple Silicon / M1 binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
           - runner: macos-11
             os: darwin
             arch: amd64
+          - runner: macos-13-xlarge
+            os: darwin
+            arch: arm64
           - runner: windows-2019
             os: windows
             arch: amd64
@@ -162,14 +165,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: builds
-
-      # TODO remove this section once we have native darwin arm64 builds
-      # This step is currently necessary for the homebrew action to pick up the MacOS AMD64 package for MacOS ARM64 / M1
-      # GitHub Roadmap: https://github.com/github/roadmap/issues/528
-      - name: (Intermediate) Use Darwin AMD64 for Darwin ARM64
-        run: |
-          cp ./builds/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-amd64/* ./builds/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-amd64/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-arm64.tar.gz
-          cp ./builds/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-amd64-onefile/* ./builds/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-amd64-onefile/${{github.event.repository.name}}-${{needs.build.outputs.cli_version}}-darwin-arm64-onefile.tar.gz
 
       - name: Generate Checksums
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
           cd dist-bin
           # start community
           ./localstack start -d
-          ./localstack wait -t 60
+          ./localstack wait -t 180
           ./localstack status services --format plain
           ./localstack status services --format plain | grep "s3=available"
           ./localstack stop
@@ -115,7 +115,7 @@ jobs:
           cd dist-bin
           # start pro
           LOCALSTACK_API_KEY=${{ secrets.TEST_LOCALSTACK_API_KEY }} ./localstack start -d
-          ./localstack wait -t 60
+          ./localstack wait -t 180
           ./localstack status services --format plain
           ./localstack status services --format plain | grep "xray=available"
           ./localstack stop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,10 @@ jobs:
         run: make clean all
 
       - name: Setup Docker on MacOS
-        if: matrix.os == 'darwin'
+        # Install docker and start Colima on MacOS (except it's the large runner)
+        # GitHub xlarge MacOS runner cannot run Docker containers:
+        # - https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/
+        if: matrix.os == 'darwin' && matrix.runner != 'macos-13-xlarge'
         run: |
           brew install docker
           colima start
@@ -84,9 +87,10 @@ jobs:
 
       - name: Community Docker Smoke tests (Linux, MacOS)
         shell: bash
-        # GitHub Windows runner cannot run Docker containers (https://github.com/orgs/community/discussions/25491)
-        # Skip these checks for forks (forks do not have access to the LocalStack Pro API key)
-        if: matrix.os != 'windows' && !github.event.pull_request.head.repo.fork
+        # GitHub Windows and xlarge MacOS runner cannot run Docker containers:
+        # - https://github.com/orgs/community/discussions/25491
+        # - https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/
+        if: matrix.os != 'windows' && matrix.runner != 'macos-13-xlarge'
         run: |
           # Pull images to avoid making smoke tests vulnerable to system behavior (docker pull speed)
           docker pull localstack/localstack
@@ -100,9 +104,11 @@ jobs:
 
       - name: Pro Docker Smoke tests (Linux, MacOS)
         shell: bash
-        # GitHub Windows runner cannot run Docker containers (https://github.com/orgs/community/discussions/25491)
+        # GitHub Windows and xlarge MacOS runner cannot run Docker containers:
+        # - https://github.com/orgs/community/discussions/25491
+        # - https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/
         # Skip these checks for forks (forks do not have access to the LocalStack Pro API key)
-        if: matrix.os != 'windows' && !github.event.pull_request.head.repo.fork
+        if: matrix.os != 'windows' && matrix.runner != 'macos-13-xlarge' && !github.event.pull_request.head.repo.fork
         run: |
           # Pull images to avoid making smoke tests vulnerable to system behavior (docker pull speed)
           docker pull localstack/localstack-pro


### PR DESCRIPTION
## Motivation
GitHub announced yesterday that they officially support Apple Silicon / M1 runners with the new `macos-13-xlarge`.
They are pretty expensive, but with these runners we can finally build native Apple M1 binaries! 🥳 
See https://github.com/github/roadmap/issues/528 or the [blog post](https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/) for more details.

Unfortunately, the Docker smoke tests have to be disabled in the large runner, because the usage of Apple's hypervisor prevents nested virtualization. See the [docs on larger MacOS runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#limitations-for-macos-larger-runners) for more details.

Addresses #10 (which will be fixed with the next release after this PR has been merged).

## Changes
- This PR adds a new parallel M1 build and removes the previous workaround (which just uses the AMD64 binary instead, completely relying on Apple Rosetta 2 being installed).
- There's also a small change which increases the timeout in the Docker smoke test to avoid flaky tests.

## TODO
- [x] Verify manually that the built binary works well on an M1.