### PR TITLE
add cookiecutter package, add extensions dev new smoke test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           brew install docker
           colima start
 
-      - name: Non-Docker Smoke tests
+      - name: Community Non-Docker Smoke tests
         shell: bash
         run: |
           ls dist-bin/
@@ -84,6 +84,18 @@ jobs:
           ./localstack --help
           # show the config
           ./localstack config show
+
+      - name: Pro Non-Docker Smoke tests
+        shell: bash
+        # Skip these checks for forks (forks do not have access to the LocalStack Pro API key)
+        if: ${{ ! github.event.pull_request.head.repo.fork }}
+        run: |
+          # create an extension with default parameters (enter all new lines to use defaults)
+          printf "\n\n\n\n\n\n\n\n" | LOCALSTACK_API_KEY=${{ secrets.TEST_LOCALSTACK_API_KEY }} DEBUG=1 ./dist-bin/localstack extensions dev new
+          # print the directory output
+          ls -al my-localstack-extension
+          # remove it again
+          rm -rf my-localstack-extension
 
       - name: Community Docker Smoke tests (Linux, MacOS)
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ $(VENV_ACTIVATE): requirements.txt
 dist-bin/localstack build: $(VENV_ACTIVATE) main.py
 	$(VENV_RUN); pyinstaller main.py \
 		$(PYINSTALLER_ARGS) -n localstack \
+		--hidden-import cookiecutter.main \
+		--hidden-import cookiecutter.extensions \
 		--hidden-import localstack_ext.cli.localstack \
 		--additional-hooks-dir hooks
 

--- a/hooks/hook-cookiecutter.py
+++ b/hooks/hook-cookiecutter.py
@@ -1,0 +1,5 @@
+import os
+
+from PyInstaller.utils.hooks import collect_data_files
+
+datas = collect_data_files('cookiecutter')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyinstaller
 localstack==2.3.2
+cookiecutter


### PR DESCRIPTION
## Motivation
`localstack extensions dev new` depends on [cookiecutter/cookiecutter](https://github.com/cookiecutter/cookiecutter) in order to create a project stub based on the cookie cutter template in [localstack/localstack-extensions](https://github.com/localstack/localstack-extensions).
However, the PyInstaller binary build of our LocalStack CLI does not add the `cookiecutter` package to the dependencies, which is why it's not added to the final package. This results in the following error when using `localstack extensions dev new` with the binary build of the LocalStack CLI:
```
$ localstack extensions dev new
Error: this command requires the cookiecutter CLI, please run:
pip install cookiecutter
```
This PR fixes this issue by adding the package to the binary build.

## Changes
- Adds `cookiecutter` to the requirements
- Adds a hook to allow building the cookiecutter package with pyinstaller.

## Testing
- Adds a new step for Pro smoke tests which checks that `localstack extensions dev new` with all-defaults results in a newly generated python project containing the LocalStack extensions boilerplate code.