### PR TITLE
fix retry on make venv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           timeout_minutes: 5
           max_attempts: 5
           retry_wait_seconds: 120
-          command: make venv
+          command: make clean-venv venv
 
       - name: Build using pyinstaller
         shell: bash


### PR DESCRIPTION
## Motivation
The last run of the action on the 3.1 release failed with a weird error, which was actually caused by the "retry setting up the venv" step not working properly.

## Changes
- Execute the `clean-venv` target before `venv`.