### PR TITLE
fix invalid version in homebrew-tap

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -13,6 +13,9 @@ jobs:
       - name: Add published release to Homebrew Tap
         uses: Justintime50/homebrew-releaser@v1
         with:
+          # Explicitly set the version to avoid Justintime50/homebrew-releaser#39 (wrong auto-detection of "64" as version)
+          version: ${{ github.event.release.tag_name }}
+
           # The name of the homebrew tap to publish your formula to as it appears on GitHub.
           # Required - strings
           homebrew_owner: localstack


### PR DESCRIPTION
## Motivation
In https://github.com/localstack/homebrew-tap/issues/3 @mcous raised the issue of an invalid version detection for the LocalStack CLI homebrew tap. They also pointed towards a potential source of the issue: https://github.com/Justintime50/homebrew-releaser/issues/39
Thanks a lot for the pointer! This PR addresses this issue by directly setting the version in the [homebrew-releaser](https://github.com/marketplace/actions/homebrew-releaser).

## Changes
- Explicitly sets the version in the homebrew tap to mitigate the invalid version detection (see https://github.com/Justintime50/homebrew-releaser/issues/39)