### PR TITLE
migrate imports from localstack_ext to localstack.pro.core

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-11
+          - runner: macos-12
             os: darwin
             arch: amd64
           - runner: macos-13-xlarge

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ dist-bin/localstack build: $(VENV_ACTIVATE) main.py
 		--hidden-import localstack.pro.core.extensions.plugins \
 		--copy-metadata localstack_ext \
 		--collect-data localstack.pro.core \
+		--exclude-module importlib_resources \
 		--additional-hooks-dir hooks
 
 dist-dir/localstack: PYINSTALLER_ARGS=--distpath=dist-dir

--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,16 @@ $(VENV_ACTIVATE): requirements.txt
 
 dist-bin/localstack build: $(VENV_ACTIVATE) main.py
 	$(VENV_RUN); pyinstaller main.py \
+		--log-level=DEBUG \
 		$(PYINSTALLER_ARGS) -n localstack \
 		--hidden-import cookiecutter.main \
 		--hidden-import cookiecutter.extensions \
-		--hidden-import localstack_ext.cli.localstack \
-		--hidden-import localstack_ext.plugins \
 		--hidden-import localstack.dev.run.configurators \
-		--hidden-import localstack_ext.extensions.plugins \
-		--hidden-import localstack_ext.extensions.bootstrap \
+		--hidden-import localstack.pro.core.plugins \
+		--hidden-import localstack.pro.core.cli.localstack \
+		--hidden-import localstack.pro.core.extensions.plugins \
+		--copy-metadata localstack_ext \
+		--collect-data localstack.pro.core \
 		--additional-hooks-dir hooks
 
 dist-dir/localstack: PYINSTALLER_ARGS=--distpath=dist-dir

--- a/hooks/hook-localstack_ext.py
+++ b/hooks/hook-localstack_ext.py
@@ -1,4 +1,0 @@
-from PyInstaller.utils.hooks import copy_metadata, collect_data_files
-
-# make sure to add the entrypoints data for localstack-ext
-datas = copy_metadata('localstack_ext') + collect_data_files('localstack_ext')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyinstaller
-localstack==3.5.1.dev20240718085020
+localstack==3.5.1.dev20240718105800
 cookiecutter

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyinstaller
-localstack==3.5.0
+localstack==3.5.1.dev20240718085020
 cookiecutter


### PR DESCRIPTION
## Motivation
After migrating `localstack/localstack` to implicit namespace packaging with https://github.com/localstack/localstack/pull/11190, we are now moving towards namespace packages for our Pro code, which comes with some necessary adjustments of any imports from Pro: `localstack_ext` becomes `localstack.pro.core`.

This PR prepares the adjustment of the imports and should be merged as soon as the first dev package with the new namespace packaging in the `localstack_ext` distribution is out.

Depends on https://github.com/localstack/localstack-ext/pull/3221.

## Changes
- Adjusts the hidden imports for PyInstaller when building the binary CLI to the new namespace packages in LocalStack Pro.

## TODO
- [x] Wait for https://github.com/localstack/localstack-ext/pull/3208 to be merged and published as a dev package.