### PR TITLE
removed exclude module and added \n to cli command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
         if: ${{ ! github.event.pull_request.head.repo.fork }}
         run: |
           # create an extension with default parameters (enter all new lines to use defaults)
-          printf "\n\n\n\n\n\n\n\n" | LOCALSTACK_API_KEY=${{ secrets.TEST_LOCALSTACK_API_KEY }} DEBUG=1 ./dist-bin/localstack extensions dev new
+          printf "\n\n\n\n\n\n\n\n\n" | LOCALSTACK_API_KEY=${{ secrets.TEST_LOCALSTACK_API_KEY }} DEBUG=1 ./dist-bin/localstack extensions dev new
           # print the directory output
           ls -al my-localstack-extension
           # remove it again

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ dist-bin/localstack build: $(VENV_ACTIVATE) main.py
 		--hidden-import localstack.pro.core.extensions.plugins \
 		--copy-metadata localstack_ext \
 		--collect-data localstack.pro.core \
-		--exclude-module importlib_resources \
 		--additional-hooks-dir hooks
 
 dist-dir/localstack: PYINSTALLER_ARGS=--distpath=dist-dir


### PR DESCRIPTION
# Motivation

In the process of running test for the release, we discovered 2 issues that this pr aims to address.

- An error raised by pyinstaller `Target module "importlib_resources" already imported as "ExcludedModule('importlib_resources',)".`
- An error raised in the `Pro Non-Docker Smoke Test`
```
❌ Error: EOF when reading a line
LocalStack extension.):   [3/9] project_slug (my-localstack-extension):   [4/9] module_name (my_localstack_extension):   [5/9] class_name (MyLocalstackExtension):   [6/9] full_name (Jane Doe):   [7/9] email (jane@example.com):   [8/9] github_username (janedoe):   [9/9] version (0.1.0): 
```

# Changes

- Removed `--exclude-module importlib_resources \` to prevent import conflict issue as `importlib_resources` is vendored with setuptools
- Added an extra line to the create script as a new option now exists when creating an extension with the `localstack extensions dev new` command