### PR TITLE
Generate and install shell completions

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -45,6 +45,7 @@ jobs:
           install: |
             libexec.install Dir["*"]
                 bin.install_symlink libexec/"localstack"
+                generate_completions_from_executable(bin/"localstack", "completion")
 
           # Custom test command for your formula so you can run `brew test`.
           # Optional - string


### PR DESCRIPTION
This PR enables the auto generation and installation of shell completions through brew's `generate_completions_from_executable`

Tested it in my fork: https://github.com/CVirus/localstack-cli/actions/runs/11195426926/job/31123073196#step:3:66

Fixes: localstack/homebrew-tap#4