### PR TITLE
fix localstack CLI version detection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,8 +148,10 @@ jobs:
         id: cli_version
         shell: bash
         run: |
-          dist-bin/localstack --version
-          echo "cli_version=$(dist-bin/localstack --version)" >> $GITHUB_OUTPUT
+          VERSION_OUTPUT=$(dist-bin/localstack --version)
+          echo $VERSION_OUTPUT
+          # using bash parameter expansion to remove the part after the last space, since sed won't work on MacOS
+          echo "cli_version=${VERSION_OUTPUT##* }" >> $GITHUB_OUTPUT
 
       - name: Archive distribution (Linux, MacOS)
         if: matrix.os != 'windows'


### PR DESCRIPTION
## Motivation
https://github.com/localstack/localstack/pull/11474 changed the output of `localstack --version`.
This broke the version detection in out GitHub pipeline.
This PR fixes this by removing everything before (including) the last space character.
Unfortunately, `sed` isn't working well on MacOS which is why we are using bash parameter expansion to do that.

## Changes
- Trim the version output such that we get the plain CLI version.