### PR TITLE
Upgrade minimum-version runners and fix Docker smoke tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,9 @@ jobs:
           # start community
           ./localstack start -d
           ./localstack wait -t 180
+          # TODO this is a hotfix to capture the first build of the service catalog which takes longer than
+          # the allowed timeout in `localstack status services` (2s)
+          curl http://localhost.localstack.cloud:4566/_localstack/health
           ./localstack status services --format plain
           ./localstack status services --format plain | grep "s3=available"
           ./localstack stop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-12
+          - runner: macos-13
             os: darwin
             arch: amd64
           - runner: macos-13-xlarge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           - runner: windows-2019
             os: windows
             arch: amd64
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             os: linux
             arch: amd64
           - runner: buildjet-2vcpu-ubuntu-2204-arm


### PR DESCRIPTION
# Motivation

Currently, we're running into two issues with the CLI build:

1. The macos-12 runner is deprecated, it needs to be replaced with the oldest currently supported runner: macos-13
2. The Ubuntu 20.04 runner is failing

# Changes

- Upgrade macos-12 to macos-13
- Upgrade Ubuntu to 22.04 as 20.04 will be EOL in May 2025
- Add a manual curl to the health endpoint before calling `localstack status services` as the first call now reliably takes longer than the 2s timeout defined in `localstack-core/localstack/cli/localstack.py:390`