### PR TITLE
remove workaround for status timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,9 +114,6 @@ jobs:
           # start community
           ./localstack start -d
           ./localstack wait -t 180
-          # TODO this is a hotfix to capture the first build of the service catalog which takes longer than
-          # the allowed timeout in `localstack status services` (2s)
-          curl http://localhost.localstack.cloud:4566/_localstack/health
           ./localstack status services --format plain
           ./localstack status services --format plain | grep "s3=available"
           ./localstack stop


### PR DESCRIPTION
With #33 a workaround was introduced to avoid issues with `localstack status services` right after starting the community edition. This workaround is removed since the issue has been fixed with localstack/localstack#12341