### PR TITLE
Upgrade windows runner after removal of windows-2019

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           - runner: macos-13-xlarge
             os: darwin
             arch: arm64
-          - runner: windows-2019
+          - runner: windows-2022
             os: windows
             arch: amd64
           - runner: ubuntu-22.04


### PR DESCRIPTION
## Motivation
With the 30th of June the [`windows-2019` runners are not available anymore on GitHub](https://github.com/actions/runner-images/issues/12045).
In order to use the oldest possible glibc version to build the executables (since glibc is forward compatible) we are upgrading to the now oldest available runner version, which is `windows-2022`.

## Changes
- Replace `windows-2019` with `windows-2022` in the build workflow.