### PR TITLE
switch from deprecated macos 13 to 14/15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-13
+          - runner: macos-15-intel
             os: darwin
             arch: amd64
-          - runner: macos-13-xlarge
+          - runner: macos-14
             os: darwin
             arch: arm64
           - runner: windows-2022


### PR DESCRIPTION
## Motivation
GitHub is phasing out support for MacOS 13, this PR upgrades our pipelines to use MacOS 14 instead.

## Changes
- Switch from `macos-13-xlarge` to `macos-14` for darwin arm64.
- Switch from `macos-13` to `macos-15-intel` for darwin amd64.