### PR TITLE
ci: upgrade OpenSSL on macOS runners before building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,19 +51,10 @@ jobs:
       - name: Create virtual environment
         uses: nick-fields/retry@v4
         with:
-          timeout_minutes: 10
+          timeout_minutes: 5
           max_attempts: 5
           retry_wait_seconds: 120
           command: make clean-venv venv
-        env:
-          # cryptography has no pre-built wheel for macOS x86_64 and builds from
-          # source via Rust. PKG_CONFIG_PATH (set by setup-python) points to
-          # Python's own OpenSSL, which can have newer headers than the Homebrew
-          # libssl.3.dylib that PyInstaller later bundles — causing a
-          # symbol-not-found crash at runtime. Pinning OPENSSL_DIR to Homebrew
-          # ensures openssl-sys compiles and links against the exact same dylib
-          # that PyInstaller will bundle.
-          OPENSSL_DIR: ${{ matrix.runner == 'macos-15-intel' && '/usr/local/opt/openssl@3' || '' }}
 
       - name: Build using pyinstaller
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,10 @@ jobs:
           retry_wait_seconds: 120
           command: make clean-venv venv
 
+      - name: Upgrade OpenSSL on MacOS
+        if: matrix.os == 'darwin'
+        run: brew upgrade openssl@3 || brew install openssl@3
+
       - name: Build using pyinstaller
         shell: bash
         run: make clean all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,10 +58,11 @@ jobs:
         env:
           # cryptography has no pre-built wheel for macOS x86_64 and builds from
           # source via Rust. PKG_CONFIG_PATH (set by setup-python) points to
-          # Python's own OpenSSL, which can differ from the Homebrew libssl.3.dylib
-          # that PyInstaller later bundles — causing a symbol-not-found crash at
-          # runtime. Forcing static linking eliminates the dylib dependency entirely.
-          OPENSSL_STATIC: ${{ matrix.runner == 'macos-15-intel' && '1' || '' }}
+          # Python's own OpenSSL, which can have newer headers than the Homebrew
+          # libssl.3.dylib that PyInstaller later bundles — causing a
+          # symbol-not-found crash at runtime. Pinning OPENSSL_DIR to Homebrew
+          # ensures openssl-sys compiles and links against the exact same dylib
+          # that PyInstaller will bundle.
           OPENSSL_DIR: ${{ matrix.runner == 'macos-15-intel' && '/usr/local/opt/openssl@3' || '' }}
 
       - name: Build using pyinstaller

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,9 @@ jobs:
           command: make clean-venv venv
 
       - name: Upgrade OpenSSL on MacOS
+        # The cryptography wheel's Rust extension references _SSL_get0_group_name (added in
+        # OpenSSL 3.2). Without this upgrade, PyInstaller may bundle an older libssl.3.dylib
+        # from the runner that lacks the symbol, causing a crash at runtime.
         if: matrix.os == 'darwin'
         run: brew upgrade openssl@3 || brew install openssl@3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,16 @@ jobs:
         with:
           python-version-file: .python-version
 
+      - name: Pin cryptography on macOS Intel
+        # cryptography 49+ dropped macOS x86_64 wheel support and uses AWS-LC as its
+        # Rust backend, producing a _rust.abi3.so that references _SSL_get0_group_name
+        # — a symbol absent from the standard OpenSSL libssl.3.dylib that PyInstaller
+        # bundles. Constrain to <49 to get the last universal2 wheel with bundled OpenSSL.
+        if: matrix.runner == 'macos-15-intel'
+        run: |
+          echo "cryptography<49" > "$RUNNER_TEMP/constraints.txt"
+          echo "PIP_CONSTRAINT=$RUNNER_TEMP/constraints.txt" >> "$GITHUB_ENV"
+
       # Add a retry to avoid issues when this action is running
       # right after the package is published on PyPi
       # (and might not be distributed in the CDN yet)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,17 +51,18 @@ jobs:
       - name: Create virtual environment
         uses: nick-fields/retry@v4
         with:
-          timeout_minutes: 5
+          timeout_minutes: 10
           max_attempts: 5
           retry_wait_seconds: 120
           command: make clean-venv venv
-
-      - name: Upgrade OpenSSL on MacOS
-        # The cryptography wheel's Rust extension references _SSL_get0_group_name (added in
-        # OpenSSL 3.2). Without this upgrade, PyInstaller may bundle an older libssl.3.dylib
-        # from the runner that lacks the symbol, causing a crash at runtime.
-        if: matrix.os == 'darwin'
-        run: brew upgrade openssl@3 || brew install openssl@3
+        env:
+          # cryptography has no pre-built wheel for macOS x86_64 and builds from
+          # source via Rust. PKG_CONFIG_PATH (set by setup-python) points to
+          # Python's own OpenSSL, which can differ from the Homebrew libssl.3.dylib
+          # that PyInstaller later bundles — causing a symbol-not-found crash at
+          # runtime. Forcing static linking eliminates the dylib dependency entirely.
+          OPENSSL_STATIC: ${{ matrix.runner == 'macos-15-intel' && '1' || '' }}
+          OPENSSL_DIR: ${{ matrix.runner == 'macos-15-intel' && '/usr/local/opt/openssl@3' || '' }}
 
       - name: Build using pyinstaller
         shell: bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyinstaller
 localstack==2026.5.0
 cookiecutter==2.6.0
+cryptography<49

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pyinstaller
 localstack==2026.5.0
 cookiecutter==2.6.0
-cryptography<49


### PR DESCRIPTION
## Summary
This issue was discovered [in this run](https://github.com/localstack/localstack-cli/actions/runs/27922084353/job/82643001047) triggerd for #54:

```
error resolving PluginSpec for plugin localstack_cli.plugins.cli.pro
Traceback (most recent call last):
  File "plux/runtime/resolve.py", line 50, in to_plugin_spec
  File "importlib/metadata/__init__.py", line 179, in load
  File "importlib/__init__.py", line 88, in import_module
  File "<frozen importlib._bootstrap>", line 1395, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "pyimod02_importers.py", line 457, in exec_module
  File "localstack_cli/pro/core/cli/localstack.py", line 11, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "localstack_cli/pro/core/cli/cloud_pods.py", line 23, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "localstack_cli/pro/core/bootstrap/auth.py", line 8, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "jwt/__init__.py", line 1, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "jwt/api_jwk.py", line 8, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "jwt/algorithms.py", line 23, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "jwt/utils.py", line 7, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "cryptography/hazmat/primitives/asymmetric/ec.py", line 11, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "cryptography/exceptions.py", line 9, in <module>
ImportError: dlopen(/var/folders/2g/92mj4pfn1s5b011gllmmvkfw0000gn/T/_MEI11q7hj/cryptography/hazmat/bindings/_rust.abi3.so, 0x0002): Symbol not found: _SSL_get0_group_name
  Referenced from: <0B82270C-7CBC-3E16-8BB3-C36A2411AD85> /private/var/folders/2g/92mj4pfn1s5b011gllmmvkfw0000gn/T/_MEI11q7hj/cryptography/hazmat/bindings/_rust.abi3.so
  Expected in:     <9B344E3E-5859-3A34-BEDE-FD3F59BB3704> /private/var/folders/2g/92mj4pfn1s5b011gllmmvkfw0000gn/T/_MEI11q7hj/libssl.3.dylib
Usage: localstack [OPTIONS] COMMAND [ARGS]...
Try 'localstack --help' for help.
```

- The `macos-15-intel` smoke test was crashing because the `cryptography` wheel's Rust extension (`_rust.abi3.so`) references `_SSL_get0_group_name` (added in OpenSSL 3.2), but PyInstaller was bundling an older `libssl.3.dylib` from the runner that doesn't export that symbol.
- This is because cryptography dropped support for MacOS x86_64 altogether with https://github.com/pyca/cryptography/issues/13520.
- This is why this PR pins the `cryptography` version to `<49` for MacOS x86_64.

**This is just a dirty fix to keep the CLI alive. We should officially deprecate the CLI for x86_64 MacOS as well.**

## Test plan

- [x] Verify the `build (macos-15-intel, darwin, amd64)` job passes the Non-Docker Smoke tests step
- [x] Verify no regression on `macos-14` (arm64) and other runners